### PR TITLE
support for branch label and IC/ICA scores from newick output of RAxML

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ npm install
 gulp build-browser
 ```
 
+## Branch label support and IC/ICA score
+
+Anything in front of the branch length and in between `[]` will be interpreted as branch label and it will be passed to the JSON format in with the `branch_label` key.
+
+### IC/ICA scores from RAxML.
+
+RAxML passes the Internode Certainty (IC) and the IC All (ICA) scores for each node as `float, float` formated branch labels<sup>1</sup>.
+
+Here, branch labels with this format specific will be automatically annotated in the JSON tree with the keys `IC` and `ICA` respectively. Unless explicitly passed `false` to the option `IC_ICA` of the `parse_newick` function (`IC_ICA` is default to `true`):
+
+```javascript
+var tree = newick.parse_newick('((human:0.2, chimp:0.3)primates:0.1[0.30,0.45], mouse:0.5)vertebrates:0.7[0.75,0.79]', IC_ICA = false)
+``` 
+
+#### Reference
+
+1 - [Leonidas Salichos, Alexandros Stamatakis, Antonis Rokas; Novel Information Theory-Based Measures for Quantifying Incongruence among Phylogenetic Trees. Mol Biol Evol 2014; 31 (5): 1261-1271. doi: 10.1093/molbev/msu061](https://academic.oup.com/mbe/article-lookup/doi/10.1093/molbev/msu061)
+
 ## Feedback
 Please, send any feedback to emepyc@gmail.com.
 Bug reports and feature requests are welcome in the [issue tracker](https://github.com/tntvis/tnt.newick/issues/new)

--- a/src/newick.js
+++ b/src/newick.js
@@ -118,7 +118,14 @@ module.exports = {
 		}
 		else {
 			if (token === ']') {
-				tree.branch_label = branch_label
+				IC_scores = _get_IC_from_RAxML(branch_label)
+				if (IC_scores) {
+					tree.IC = IC_scores[0]
+					tree.ICA = IC_scores[1]
+				}
+				else {
+					tree.branch_label = branch_label
+				}
 				branch_label = ''
 				not_branch_label = true
 			}
@@ -127,7 +134,18 @@ module.exports = {
 			}
 		}
 	}
+
+	function _get_IC_from_RAxML(branch_label) {
+		scores = branch_label.split(',')
+		scores = scores.map(parseFloat)
+		if (scores.length === 2)
+			return scores
+		else
+			return false
+	}
+
 	return tree;
+
     },
 
     parse_nhx : function (s) {

--- a/src/newick.js
+++ b/src/newick.js
@@ -77,7 +77,7 @@
  */
 
 module.exports = {
-    parse_newick : function(s) {
+    parse_newick : function(s, IC_ICA = true) {
 	var ancestors = [];
 	var tree = {};
 	var tokens = s.split(/\s*(;|\(|\)|,|:|\[|\])\s*/);
@@ -119,7 +119,7 @@ module.exports = {
 		else {
 			if (token === ']') {
 				IC_scores = _get_IC_from_RAxML(branch_label)
-				if (IC_scores) {
+				if (IC_scores && IC_ICA) {
 					tree.IC = IC_scores[0]
 					tree.ICA = IC_scores[1]
 				}

--- a/src/newick.js
+++ b/src/newick.js
@@ -21,28 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * Example tree (from http://en.wikipedia.org/wiki/Newick_format):
+ * * * * *
+ * 
+ * This version has been modified by Davi Ortega, no copyrights from my side - just have fun.
+ * 
+ * Included features:
+ * * reads branch labels
+ * 
+ * * * * *
+ * 
+ * Reads branch labels - anything after ":" and between 
+ * 
+ * Example tree ( modified to include branch labels from http://en.wikipedia.org/wiki/Newick_format):
  *
- * +--0.1--A
- * F-----0.2-----B            +-------0.3----C
- * +------------------0.5-----E
- *                            +---------0.4------D
+ * +--0.1[40]--A
+ * F-----0.2[20]-----B            +-------0.3[95]----C
+ * +------------------0.5[75]-----E
+ *                                +---------0.4[20]------D
  *
  * Newick format:
- * (A:0.1,B:0.2,(C:0.3,D:0.4)E:0.5)F;
+ * (A:0.1[40],B:0.2[20],(C:0.3[95],D:0.4[20])E:0.5[75])F;
  *
  * Converted to JSON:
  * {
  *   name: "F",
  *   branchset: [
- *     {name: "A", length: 0.1},
- *     {name: "B", length: 0.2},
+ *     {name: "A", length: 0.1, bname: "40"},
+ *     {name: "B", length: 0.2, bname: "20"},
  *     {
- *       name: "E",
- *       length: 0.5,
+ *       name: "E", length: 0.5, bname: "75",
  *       branchset: [
- *         {name: "C", length: 0.3},
- *         {name: "D", length: 0.4}
+ *         {name: "C", length: 0.3, bname: "95"},
+ *         {name: "D", length: 0.4, bname: "20"}
  *       ]
  *     }
  *   ]
@@ -56,41 +66,66 @@
  *     }
  *   ]
  * }
+ * 
+ * 
+ * RAxML IC support
+ * 
+ * (A:0.1,B:0.2,(C:0.3,D:0.4)E:0.5[0.5,0.6])F;
+ * 
+ * 
+ * 
  */
 
 module.exports = {
     parse_newick : function(s) {
 	var ancestors = [];
 	var tree = {};
-	var tokens = s.split(/\s*(;|\(|\)|,|:)\s*/);
+	var tokens = s.split(/\s*(;|\(|\)|,|:|\[|\])\s*/);
 	var subtree;
+	var not_branch_label = true
+	var branch_label = ''
 	for (var i=0; i<tokens.length; i++) {
 	    var token = tokens[i];
-	    switch (token) {
-            case '(': // new branchset
-		subtree = {};
-		tree.children = [subtree];
-		ancestors.push(tree);
-		tree = subtree;
-		break;
-            case ',': // another branch
-		subtree = {};
-		ancestors[ancestors.length-1].children.push(subtree);
-		tree = subtree;
-		break;
-            case ')': // optional name next
-		tree = ancestors.pop();
-		break;
-            case ':': // optional length next
-		break;
-            default:
-		var x = tokens[i-1];
-		if (x == ')' || x == '(' || x == ',') {
-		    tree.name = token;
-		} else if (x == ':') {
-		    tree.branch_length = parseFloat(token);
+		if (not_branch_label) {
+			switch (token) {
+				case '(': // new branchset
+					subtree = {};
+					tree.children = [subtree];
+					ancestors.push(tree);
+					tree = subtree;
+					break;
+				case ',': // another branch
+					subtree = {};
+					ancestors[ancestors.length-1].children.push(subtree);
+					tree = subtree;
+					break;
+				case ')': // optional name next
+					tree = ancestors.pop();
+					break;
+				case ':': // optional length next
+					break;
+				case '[':
+					not_branch_label = false
+					break
+				default:
+					var x = tokens[i-1];
+					if (x == ')' || x == '(' || x == ',') {
+						tree.name = token;
+					} else if (x == ':') {				
+						tree.branch_length = parseFloat(token);
+					} 
+			}
 		}
-	    }
+		else {
+			if (token === ']') {
+				tree.branch_label = branch_label
+				branch_label = ''
+				not_branch_label = true
+			}
+			else {
+				branch_label += token
+			}
+		}
 	}
 	return tree;
     },

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,15 @@ describe ("parse_newick", function () {
 	assert.property (tree.children[0], "branch_length");
 	assert.closeTo (tree.children[0].branch_length, 0.1, 0.05);
     });
+
+	describe.only('Support to branch labels', function() {
+		it('auto recongnize branch', function() {
+			var tree = newick.parse_newick('((human:0.2, chimp:0.3)primates:0.1[30], mouse:0.5)vertebrates:0.7[75]')
+			assert.strictEqual(tree.branch_label, "75")
+			assert.strictEqual(tree.children[0].branch_label, "30")
+		})
+		it('Reads IC/ICA values as branch labels from RAxML trees')
+	})
 });
 
 describe ("parse_nhx", function () {
@@ -67,4 +76,3 @@ describe ("parse_nhx", function () {
 	assert.equal (tree.children[0].children[0].taxon_id, 4);
     });
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,11 @@ describe ("parse_newick", function () {
 			assert.closeTo(tree.children[0].IC, 0.3, 0.05)
 			assert.closeTo(tree.children[0].ICA, 0.45, 0.05)
 		})
+		it('Ignore IC/ICA format if explicitely asked to', function() {
+			var tree = newick.parse_newick('((human:0.2, chimp:0.3)primates:0.1[0.30,0.45], mouse:0.5)vertebrates:0.7[0.75,0.79]', IC_ICA = false)
+			assert.strictEqual(tree.branch_label, "0.75,0.79")
+			assert.strictEqual(tree.children[0].branch_label, "0.30,0.45")
+		})
 	})
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,13 +44,19 @@ describe ("parse_newick", function () {
 	assert.closeTo (tree.children[0].branch_length, 0.1, 0.05);
     });
 
-	describe.only('Support to branch labels', function() {
-		it('auto recongnize branch', function() {
+	describe('Support to branch labels', function() {
+		it('Reads branch label', function() {
 			var tree = newick.parse_newick('((human:0.2, chimp:0.3)primates:0.1[30], mouse:0.5)vertebrates:0.7[75]')
 			assert.strictEqual(tree.branch_label, "75")
 			assert.strictEqual(tree.children[0].branch_label, "30")
 		})
-		it('Reads IC/ICA values as branch labels from RAxML trees')
+		it('Reads branch label as IC/ICA values if branch label in [float,float] format from RAxML trees', function() {
+			var tree = newick.parse_newick('((human:0.2, chimp:0.3)primates:0.1[0.30,0.45], mouse:0.5)vertebrates:0.7[0.75,0.79]')
+			assert.closeTo(tree.IC, 0.75, 0.05)
+			assert.closeTo(tree.ICA, 0.79, 0.05)
+			assert.closeTo(tree.children[0].IC, 0.3, 0.05)
+			assert.closeTo(tree.children[0].ICA, 0.45, 0.05)
+		})
 	})
 });
 


### PR DESCRIPTION
Hi there,

This is probably not the best way to provide support for branch labels and IC/ICA scores from RAxML format but it passes some minor tests without breaking anything else.

Anyways, let me know if there is any issue.

Cheers
D.